### PR TITLE
Remove assert on the directory in which an executable is to be found thus fixing cross-compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,6 @@ fn get_test_bin_dir() -> std::path::PathBuf {
     let current_dir = current_exe
         .parent()
         .expect("Failed to get the directory of the integration test binary");
-    assert!(
-        current_dir.ends_with("target/debug/deps") || current_dir.ends_with("target/release/deps")
-    );
 
     let test_bin_dir = current_dir
         .parent()


### PR DESCRIPTION
Removed the assert, as discussed.