### PR TITLE
Add macro and deprecate function (try 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+## [0.5.0] - 2025-07-11
+
+### Added
+
+- A macro was added and the old function was deprecated by [@MichaelMcDonnell](https://github.com/MichaelMcDonnell) at the suggestion of [@epage](https://github.com/epage).
 - Windows and cross (Linux musl) CI by [@MichaelMcDonnell](https://github.com/MichaelMcDonnell).
 
 ### Fixed
@@ -43,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The initial release by [@MichaelMcDonnell](https://github.com/MichaelMcDonnell).
 
-[Unreleased]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/MichaelMcDonnell/test_bin/compare/v0.1.0...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "test_bin"
-version = "0.4.0"
+version = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_bin"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Michael Mc Donnell <michael@mcdonnell.dk>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are writing a command-line interface app then it is useful to write an in
 Here is the basic usage:
 
 ```rust
-let output = test_bin::get_test_bin("my_cli_app")
+let output = test_bin::get_test_bin!("my_cli_app")
     .output()
     .expect("Failed to start my_binary");
 assert_eq!(
@@ -18,11 +18,19 @@ assert_eq!(
 );
 ```
 
+NOTE: The `get_test_bin` function was deprecated in version 0.5.0. Please use
+the macro instead.
+
 ## Acknowledgements
 
 The `cargo` and `ripgrep` crates were used as inspiration. They both test their
 binaries using a similar approach. The `cargo` crate's documentation and license
 was used as a starting point.
+
+Thanks to Ewan Higgs (@ehiggs), and Chris Greenaway (@ChrisGreenaway) for their
+fixes.
+
+The code was later changed to a macro via a suggestion by Ed Page (@epage).
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! basic usage:
 //!
-//! ```no_run
-//! let output = test_bin::get_test_bin("my_cli_app")
+//! ```ignore
+//! let output = test_bin::get_test_bin!("my_cli_app")
 //!     .output()
 //!     .expect("Failed to start my_binary");
 //! assert_eq!(
@@ -21,6 +21,38 @@
 //!
 //! Refer to the [`std::process::Command` documentation](https://doc.rust-lang.org/std/process/struct.Command.html)
 //! for how to pass arguments, check exit status and more.
+//!
+//! NOTE: There is also the older non-macro `get_test_bin` which has been
+//! deprecated. I has been deprecated because there is work to allow cargo to
+//! write its output to new paths. See [Cargo issue 14125](https://github.com/rust-lang/cargo/issues/14125).
+//!
+//! The `get_test_bin` macro uses the `CARGO_BIN_EXE_<name>` environment
+//! variable which was introduced in [Rust 1.43 released on 23 April 2020](https://releases.rs/docs/1.43.0/).
+//!
+
+// Returns the crate's binary as a `Command` that can be used for integration
+/// tests.
+///
+/// # Arguments
+///
+/// * `bin_name` - The name of the binary you want to test.
+///
+/// # Remarks
+///
+/// It will fail to compile if the `bin_name` is incorrect. The `bin_name` is
+/// used for creating an environment variable.
+#[macro_export]
+macro_rules! get_test_bin {
+    ($x:expr) => {
+        {
+            // Get path string. See the CARGO_BIN_EXE_<name> documentation:
+            // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+            let path_str = env!(concat!("CARGO_BIN_EXE_", $x));
+            // Create command
+            std::process::Command::new(path_str)
+        }
+    };
+}
 
 /// Returns the crate's binary as a `Command` that can be used for integration
 /// tests.
@@ -32,11 +64,23 @@
 /// # Remarks
 ///
 /// It panics on error. This is by design so the test that uses it fails.
+#[deprecated(since = "0.5.0", note = "please use `get_test_bin!` macro instead")]
 pub fn get_test_bin(bin_name: &str) -> std::process::Command {
     // Create full path to binary
     let mut path = get_test_bin_dir();
     path.push(bin_name);
     path.set_extension(std::env::consts::EXE_EXTENSION);
+
+    if !path.exists() {
+        // Print all environment variables.
+        for (key, value) in std::env::vars() {
+            println!("{key}: {value}");
+        }
+        let path: &'static str = env!("PATH");
+        println!("the $PATH variable at the time of compiling was: {path}");
+        let build_dir = std::env::var("CARGO_BIN_EXE_test_bin").unwrap();
+        panic!("Environment variable is {}", build_dir);
+    }
 
     assert!(path.exists());
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,18 @@
 #[test]
 fn basic_usage() {
+    let output = test_bin::get_test_bin!("test_bin")
+        .output()
+        .expect("Failed to start test_bin");
+
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Output from my CLI app!\n"
+    );
+}
+
+#[test]
+fn basic_usage_deprecated() {
+    #[allow(deprecated)]
     let output = test_bin::get_test_bin("test_bin")
         .output()
         .expect("Failed to start test_bin");


### PR DESCRIPTION
Ed Page (@epage) suggested replacing the function with a macro. This is because Cargo is planning to move where the output is written.

I needed to also change `no_run` in the documentation to `ignore`.

The version in Cargo.lock needed to be 3 instead of 4.