### PR TITLE
Undeprecate `get_test_bin` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Undeprecated the `get_test_bin` function by [@MichaelMcDonnell](https://github.com/MichaelMcDonnell) at the suggestion of [@epage](https://github.com/epage). Cargo was changed in a way that made the macro unnecessary.
+
 ## [0.5.0] - 2025-07-11
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! basic usage:
 //!
 //! ```ignore
-//! let output = test_bin::get_test_bin!("my_cli_app")
+//! let output = test_bin::get_test_bin("my_cli_app")
 //!     .output()
 //!     .expect("Failed to start my_binary");
 //! assert_eq!(
@@ -22,37 +22,16 @@
 //! Refer to the [`std::process::Command` documentation](https://doc.rust-lang.org/std/process/struct.Command.html)
 //! for how to pass arguments, check exit status and more.
 //!
-//! NOTE: There is also the older non-macro `get_test_bin` which has been
-//! deprecated. I has been deprecated because there is work to allow cargo to
-//! write its output to new paths. See [Cargo issue 14125](https://github.com/rust-lang/cargo/issues/14125).
+//! NOTE: The `get_test_bin` function was deprecated in version 0.5.0 in favor
+//! of the `get_test_bin!` macro and then undeprecated in version 0.6.0. The
+//! macro was added because there was talk of changing cargo so the function
+//! wouldn't work. Fortunately, cargo was changed so that the macro wasn't
+//! needed. The `get_test_bin` function is the recommended way of using
+//! this crate. See [Cargo issue 14125](https://github.com/rust-lang/cargo/issues/14125).
 //!
-//! The `get_test_bin` macro uses the `CARGO_BIN_EXE_<name>` environment
+//! The `get_test_bin!` macro uses the `CARGO_BIN_EXE_<name>` environment
 //! variable which was introduced in [Rust 1.43 released on 23 April 2020](https://releases.rs/docs/1.43.0/).
 //!
-
-// Returns the crate's binary as a `Command` that can be used for integration
-/// tests.
-///
-/// # Arguments
-///
-/// * `bin_name` - The name of the binary you want to test.
-///
-/// # Remarks
-///
-/// It will fail to compile if the `bin_name` is incorrect. The `bin_name` is
-/// used for creating an environment variable.
-#[macro_export]
-macro_rules! get_test_bin {
-    ($x:expr) => {
-        {
-            // Get path string. See the CARGO_BIN_EXE_<name> documentation:
-            // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-            let path_str = env!(concat!("CARGO_BIN_EXE_", $x));
-            // Create command
-            std::process::Command::new(path_str)
-        }
-    };
-}
 
 /// Returns the crate's binary as a `Command` that can be used for integration
 /// tests.
@@ -64,7 +43,6 @@ macro_rules! get_test_bin {
 /// # Remarks
 ///
 /// It panics on error. This is by design so the test that uses it fails.
-#[deprecated(since = "0.5.0", note = "please use `get_test_bin!` macro instead")]
 pub fn get_test_bin(bin_name: &str) -> std::process::Command {
     // Create full path to binary
     let mut path = get_test_bin_dir();
@@ -105,4 +83,37 @@ fn get_test_bin_dir() -> std::path::PathBuf {
         .parent()
         .expect("Failed to get the binary folder");
     test_bin_dir.to_owned()
+}
+
+/// Returns the crate's binary as a `Command` that can be used for integration
+/// tests.
+///
+/// # Arguments
+///
+/// * `bin_name` - The name of the binary you want to test. It must be a string literal.
+///
+/// # Remarks
+///
+/// It will fail to compile if the `bin_name` is incorrect. The `bin_name` is
+/// used for creating an environment variable.
+///
+/// If you want to not use a string literal every time then you can define a
+/// macro that returns a string literal:
+/// ```rust
+/// macro_rules! my_cli_app {
+///    () => ( "my_cli_app" )
+/// }
+/// ```
+/// And then use `my_cli_app!()` as the argument.
+#[macro_export]
+macro_rules! get_test_bin {
+    ($x:expr) => {
+        {
+            // Get path string. See the CARGO_BIN_EXE_<name> documentation:
+            // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+            let path_str = env!(concat!("CARGO_BIN_EXE_", $x));
+            // Create command
+            std::process::Command::new(path_str)
+        }
+    };
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,7 @@
 #[test]
 fn basic_usage() {
-    let output = test_bin::get_test_bin!("test_bin")
+    // This is the simplest way of using the crate.
+    let output = test_bin::get_test_bin("test_bin")
         .output()
         .expect("Failed to start test_bin");
 
@@ -11,9 +12,33 @@ fn basic_usage() {
 }
 
 #[test]
-fn basic_usage_deprecated() {
-    #[allow(deprecated)]
-    let output = test_bin::get_test_bin("test_bin")
+fn macro_usage() {
+    // The macro was added because there was talk of changing cargo in a way
+    // that would have broken the `get_test_bin` function. Those plans changed
+    // and it is ok to use the function.
+    let output = test_bin::get_test_bin!("test_bin")
+        .output()
+        .expect("Failed to start test_bin");
+
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Output from my CLI app!\n"
+    );
+}
+
+macro_rules! bin_name {
+    () => {
+        "test_bin"
+    };
+}
+
+#[test]
+fn macro_usage_with_name_macro() {
+    // You unfortunately need a macro if you don't want to retype the binary
+    // name because the `concat!` macro doesn't support constant string
+    // references. You can alternatively just use the `get_test_bin` function
+    // instead.
+    let output = test_bin::get_test_bin!(bin_name!())
         .output()
         .expect("Failed to start test_bin");
 


### PR DESCRIPTION
Cargo was changed in a way that made the macro unnecessary. Bring back the old function.